### PR TITLE
Add pre-check if the dollar ($) is non-jQuery

### DIFF
--- a/jquery-bridget.js
+++ b/jquery-bridget.js
@@ -47,7 +47,7 @@ var logError = typeof console == 'undefined' ? function() {} :
 // ----- jQueryBridget ----- //
 
 function jQueryBridget( namespace, PluginClass, $ ) {
-  $ = $ || jQuery || window.jQuery;
+  $ = ($ && $.fn && $.fn.jquery) ? $ : window.jQuery;
   if ( !$ ) {
     return;
   }


### PR DESCRIPTION
This [line in the Masonry plugin dist file](https://github.com/desandro/masonry/blob/v4.0.0/dist/masonry.pkgd.js#L58) breakes code that is using the `$` with _not_ jQuery:

    function jQueryBridget( namespace, PluginClass, $ ) {
        $ = $ || jQuery || window.jQuery;

I suggest jquery-bridget will take this into account and add a check like 

    $ = $ && $.fn.jQuery ? $ : (jQuery || window.jQuery);

to not override the `$` for other libraries, or something similar.